### PR TITLE
Add Google Calendar endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REFRESH_TOKEN=your-google-refresh-token

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Google Calendar Integration
+
+Environment variables in `.env` (see `.env.example`) configure access to Google Calendar. Once set, the latest event from your primary calendar can be fetched from `/api/latest-event`.

--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 ## Google Calendar Integration
 
 Environment variables in `.env` (see `.env.example`) configure access to Google Calendar. Once set, the latest event from your primary calendar can be fetched from `/api/latest-event`.
+
+The home page includes a **Get Latest Event** button that calls this endpoint and displays the title, description and start time of the next event.

--- a/app/api/latest-event/route.ts
+++ b/app/api/latest-event/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest } from 'next/server';
+import { getLatestEvent } from '@/lib/googleCalendar';
+
+export async function GET(request: NextRequest) {
+  try {
+    const event = await getLatestEvent();
+    return Response.json(event);
+  } catch (err) {
+    console.error('Failed to fetch latest event', err);
+    return new Response('Failed to fetch latest event', { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,52 @@
-import Image from "next/image";
+'use client';
+
+import { useState } from 'react';
+
+interface CalendarEvent {
+  summary?: string;
+  description?: string;
+  start?: { dateTime?: string; date?: string };
+}
 
 export default function Home() {
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [event, setEvent] = useState<CalendarEvent | null>(null);
+  const [loading, setLoading] = useState(false);
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+  const fetchEvent = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/latest-event');
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      setEvent(data);
+    } catch (err) {
+      console.error('Failed to load event', err);
+      setEvent(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="font-sans flex flex-col items-center justify-center min-h-screen p-6 gap-6">
+      <button
+        className="bg-black text-white rounded px-4 py-2"
+        onClick={fetchEvent}
+        disabled={loading}
+      >
+        {loading ? 'Loading…' : 'Get Latest Event'}
+      </button>
+      {event && (
+        <div className="border rounded p-4 w-full max-w-md">
+          <h2 className="text-xl font-semibold">{event.summary ?? 'No title'}</h2>
+          {event.description && <p className="mt-2">{event.description}</p>}
+          {(event.start?.dateTime || event.start?.date) && (
+            <p className="mt-2 text-sm text-gray-600">
+              {new Date(event.start.dateTime ?? event.start.date ?? '').toLocaleString()}
+            </p>
+          )}
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+      )}
+    </main>
   );
 }

--- a/lib/googleCalendar.ts
+++ b/lib/googleCalendar.ts
@@ -1,0 +1,26 @@
+import { google } from 'googleapis';
+
+export async function getLatestEvent() {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  const refreshToken = process.env.GOOGLE_REFRESH_TOKEN;
+
+  if (!clientId || !clientSecret || !refreshToken) {
+    throw new Error('Missing Google API credentials');
+  }
+
+  const oauth2 = new google.auth.OAuth2(clientId, clientSecret);
+  oauth2.setCredentials({ refresh_token: refreshToken });
+
+  const calendar = google.calendar({ version: 'v3', auth: oauth2 });
+
+  const { data } = await calendar.events.list({
+    calendarId: 'primary',
+    maxResults: 1,
+    singleEvents: true,
+    orderBy: 'startTime',
+    timeMin: new Date().toISOString(),
+  });
+
+  return data.items?.[0] ?? null;
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.4.2"
+    "next": "15.4.2",
+    "googleapis": "^133.0.0"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- add env example and allow it through gitignore
- integrate Google Calendar API with oauth client
- expose `/api/latest-event` endpoint

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ec8450f4c832c9504774decfa1ded